### PR TITLE
feat: Implement date filtering for Get All Interviews

### DIFF
--- a/src/main/java/com/telusinternational/hrims/exception/InvalidDateRangeException.java
+++ b/src/main/java/com/telusinternational/hrims/exception/InvalidDateRangeException.java
@@ -1,0 +1,7 @@
+package com.telusinternational.hrims.exception;
+
+public class InvalidDateRangeException extends RuntimeException {
+    public InvalidDateRangeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/telusinternational/hrims/repository/InterviewScheduleRepository.java
+++ b/src/main/java/com/telusinternational/hrims/repository/InterviewScheduleRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository
 public interface InterviewScheduleRepository extends JpaRepository<InterviewSchedule, Long> {
     List<InterviewSchedule> findByCalendarInfo_Date(LocalDate date);
+    List<InterviewSchedule> findByCalendarInfo_DateBetween(LocalDate startDate, LocalDate endDate);
 } 

--- a/src/main/java/com/telusinternational/hrims/service/InterviewScheduleService.java
+++ b/src/main/java/com/telusinternational/hrims/service/InterviewScheduleService.java
@@ -1,11 +1,12 @@
 package com.telusinternational.hrims.service;
 
 import com.telusinternational.hrims.entity.InterviewSchedule;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface InterviewScheduleService {
     InterviewSchedule scheduleInterview(InterviewSchedule schedule);
-    List<InterviewSchedule> getAllInterviews();
+    List<InterviewSchedule> getAllInterviews(LocalDate startDate, LocalDate endDate);
     InterviewSchedule updateInterview(Long id, InterviewSchedule schedule);
     void deleteInterview(Long id);
     InterviewSchedule getInterviewById(Long id);

--- a/src/test/java/com/telusinternational/hrims/controller/InterviewScheduleControllerTest.java
+++ b/src/test/java/com/telusinternational/hrims/controller/InterviewScheduleControllerTest.java
@@ -1,0 +1,135 @@
+package com.telusinternational.hrims.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.telusinternational.hrims.entity.InterviewSchedule;
+import com.telusinternational.hrims.exception.InvalidDateRangeException;
+import com.telusinternational.hrims.service.InterviewScheduleService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(InterviewScheduleController.class)
+public class InterviewScheduleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private InterviewScheduleService interviewScheduleService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void getAllInterviews_whenNoParams_shouldReturnOkAndAllInterviews() throws Exception {
+        List<InterviewSchedule> schedules = new ArrayList<>();
+        // Add mock data if needed
+        when(interviewScheduleService.getAllInterviews(null, null)).thenReturn(schedules);
+
+        mockMvc.perform(get("/schedule"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    void getAllInterviews_withValidDateParams_shouldReturnOkAndFilteredInterviews() throws Exception {
+        LocalDate startDate = LocalDate.of(2024, 1, 1);
+        LocalDate endDate = LocalDate.of(2024, 1, 10);
+        List<InterviewSchedule> schedules = new ArrayList<>(); // Mock filtered list
+        when(interviewScheduleService.getAllInterviews(startDate, endDate)).thenReturn(schedules);
+
+        mockMvc.perform(get("/schedule")
+                        .param("startDate", "2024-01-01")
+                        .param("endDate", "2024-01-10"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    void getAllInterviews_withInvalidDateRange_shouldReturnNotFound() throws Exception {
+        LocalDate startDate = LocalDate.of(2024, 1, 10);
+        LocalDate endDate = LocalDate.of(2024, 1, 1);
+        String errorMessage = "Invalid input- End Date should be grater than start date";
+
+        when(interviewScheduleService.getAllInterviews(startDate, endDate))
+                .thenThrow(new InvalidDateRangeException(errorMessage));
+
+        ResultActions resultActions = mockMvc.perform(get("/schedule")
+                        .param("startDate", "2024-01-10")
+                        .param("endDate", "2024-01-01"))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.message").value(errorMessage));
+    }
+
+    @Test
+    void getAllInterviews_withEndDateEqualToStartDate_shouldReturnNotFound() throws Exception {
+        LocalDate startDate = LocalDate.of(2024, 1, 1);
+        LocalDate endDate = LocalDate.of(2024, 1, 1);
+        String errorMessage = "Invalid input- End Date should be grater than start date";
+
+        when(interviewScheduleService.getAllInterviews(startDate, endDate))
+                .thenThrow(new InvalidDateRangeException(errorMessage));
+
+        ResultActions resultActions = mockMvc.perform(get("/schedule")
+                        .param("startDate", "2024-01-01")
+                        .param("endDate", "2024-01-01"))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.message").value(errorMessage));
+    }
+
+    @Test
+    void getAllInterviews_withOnlyStartDateParam_shouldReturnOk() throws Exception {
+        LocalDate startDate = LocalDate.of(2024, 1, 1);
+        List<InterviewSchedule> schedules = new ArrayList<>();
+        when(interviewScheduleService.getAllInterviews(startDate, null)).thenReturn(schedules);
+
+        mockMvc.perform(get("/schedule")
+                        .param("startDate", "2024-01-01"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    void getAllInterviews_withOnlyEndDateParam_shouldReturnOk() throws Exception {
+        LocalDate endDate = LocalDate.of(2024, 1, 10);
+        List<InterviewSchedule> schedules = new ArrayList<>();
+        when(interviewScheduleService.getAllInterviews(null, endDate)).thenReturn(schedules);
+
+        mockMvc.perform(get("/schedule")
+                        .param("endDate", "2024-01-10"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    void getAllInterviews_withInvalidDateFormat_shouldReturnBadRequest() throws Exception {
+        // Spring Boot's default behavior with @DateTimeFormat is to return a 400 Bad Request
+        // if the date format is incorrect. We don't need to mock the service for this.
+        mockMvc.perform(get("/schedule")
+                        .param("startDate", "invalid-date-format")
+                        .param("endDate", "2024-01-10"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/telusinternational/hrims/service/impl/InterviewScheduleServiceImplTest.java
+++ b/src/test/java/com/telusinternational/hrims/service/impl/InterviewScheduleServiceImplTest.java
@@ -1,0 +1,109 @@
+package com.telusinternational.hrims.service.impl;
+
+import com.telusinternational.hrims.entity.InterviewSchedule;
+import com.telusinternational.hrims.exception.InvalidDateRangeException;
+import com.telusinternational.hrims.repository.InterviewScheduleRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class InterviewScheduleServiceImplTest {
+
+    @Mock
+    private InterviewScheduleRepository interviewScheduleRepository;
+
+    @InjectMocks
+    private InterviewScheduleServiceImpl interviewScheduleService;
+
+    @Test
+    void getAllInterviews_whenBothDatesProvided_andValid_shouldReturnFilteredList() {
+        LocalDate startDate = LocalDate.of(2024, 1, 1);
+        LocalDate endDate = LocalDate.of(2024, 1, 31);
+        List<InterviewSchedule> expectedSchedules = new ArrayList<>();
+        // Add some mock schedules to expectedSchedules if needed for verification
+
+        when(interviewScheduleRepository.findByCalendarInfo_DateBetween(startDate, endDate)).thenReturn(expectedSchedules);
+
+        List<InterviewSchedule> actualSchedules = interviewScheduleService.getAllInterviews(startDate, endDate);
+
+        assertEquals(expectedSchedules, actualSchedules);
+        verify(interviewScheduleRepository).findByCalendarInfo_DateBetween(startDate, endDate);
+        verify(interviewScheduleRepository, never()).findAll();
+    }
+
+    @Test
+    void getAllInterviews_whenBothDatesProvided_andEndDateBeforeStartDate_shouldThrowException() {
+        LocalDate startDate = LocalDate.of(2024, 1, 31);
+        LocalDate endDate = LocalDate.of(2024, 1, 1);
+
+        InvalidDateRangeException exception = assertThrows(InvalidDateRangeException.class, () -> {
+            interviewScheduleService.getAllInterviews(startDate, endDate);
+        });
+
+        assertEquals("Invalid input- End Date should be grater than start date", exception.getMessage());
+        verify(interviewScheduleRepository, never()).findByCalendarInfo_DateBetween(any(), any());
+        verify(interviewScheduleRepository, never()).findAll();
+    }
+
+    @Test
+    void getAllInterviews_whenBothDatesProvided_andEndDateEqualsStartDate_shouldThrowException() {
+        LocalDate startDate = LocalDate.of(2024, 1, 1);
+        LocalDate endDate = LocalDate.of(2024, 1, 1);
+
+        InvalidDateRangeException exception = assertThrows(InvalidDateRangeException.class, () -> {
+            interviewScheduleService.getAllInterviews(startDate, endDate);
+        });
+
+        assertEquals("Invalid input- End Date should be grater than start date", exception.getMessage());
+        verify(interviewScheduleRepository, never()).findByCalendarInfo_DateBetween(any(), any());
+        verify(interviewScheduleRepository, never()).findAll();
+    }
+
+    @Test
+    void getAllInterviews_whenOnlyStartDateProvided_shouldReturnAll() {
+        LocalDate startDate = LocalDate.of(2024, 1, 1);
+        List<InterviewSchedule> expectedSchedules = new ArrayList<>();
+        when(interviewScheduleRepository.findAll()).thenReturn(expectedSchedules);
+
+        List<InterviewSchedule> actualSchedules = interviewScheduleService.getAllInterviews(startDate, null);
+
+        assertEquals(expectedSchedules, actualSchedules);
+        verify(interviewScheduleRepository).findAll();
+        verify(interviewScheduleRepository, never()).findByCalendarInfo_DateBetween(any(), any());
+    }
+
+    @Test
+    void getAllInterviews_whenOnlyEndDateProvided_shouldReturnAll() {
+        LocalDate endDate = LocalDate.of(2024, 1, 31);
+        List<InterviewSchedule> expectedSchedules = new ArrayList<>();
+        when(interviewScheduleRepository.findAll()).thenReturn(expectedSchedules);
+
+        List<InterviewSchedule> actualSchedules = interviewScheduleService.getAllInterviews(null, endDate);
+
+        assertEquals(expectedSchedules, actualSchedules);
+        verify(interviewScheduleRepository).findAll();
+        verify(interviewScheduleRepository, never()).findByCalendarInfo_DateBetween(any(), any());
+    }
+
+    @Test
+    void getAllInterviews_whenNoDatesProvided_shouldReturnAll() {
+        List<InterviewSchedule> expectedSchedules = new ArrayList<>();
+        when(interviewScheduleRepository.findAll()).thenReturn(expectedSchedules);
+
+        List<InterviewSchedule> actualSchedules = interviewScheduleService.getAllInterviews(null, null);
+
+        assertEquals(expectedSchedules, actualSchedules);
+        verify(interviewScheduleRepository).findAll();
+        verify(interviewScheduleRepository, never()).findByCalendarInfo_DateBetween(any(), any());
+    }
+}


### PR DESCRIPTION
Adds the ability to filter interviews by a date range.

- Updated `InterviewScheduleRepository` with `findByCalendarInfo_DateBetween`.
- Modified `InterviewScheduleService` and `InterviewScheduleServiceImpl` to handle date parameters and validation.
- If `endDate` is not greater than `startDate`, a 404 error with a specific message is returned.
- If no dates or only one date is provided, all interviews are returned.
- Updated `InterviewScheduleController` to accept `startDate` and `endDate` query parameters.
- Added `InvalidDateRangeException` for date validation.
- Added unit tests for service and controller layers.